### PR TITLE
Switch Object to use lookup hash

### DIFF
--- a/lib/my_tank_info/object.rb
+++ b/lib/my_tank_info/object.rb
@@ -4,20 +4,20 @@ require "active_support/core_ext/string/inflections"
 module MyTankInfo
   class Object
     def initialize(attributes)
-      # this ensures that when names are provided in camelcase (BeginDateTime) 
-      # they are converted to snake_case (begin_date_time)
-      snake_case_keys = attributes&.transform_keys { |key| key.to_s.underscore }
       @original_attributes = attributes
-      @attributes = ::OpenStruct.new(snake_case_keys || {})
+
+      # this ensures that when names are provided in camelcase (BeginDateTime)
+      # they are converted to snake_case (begin_date_time)
+      @attributes = Hash(attributes).transform_keys { |key| key.to_s.underscore.to_sym }
     end
 
     def method_missing(method, *args, &block)
-      attribute = @attributes.send(method, *args, &block)
+      attribute = @attributes[method]
       attribute.is_a?(Hash) ? Object.new(attribute) : attribute
     end
 
     def respond_to_missing?(method, include_private = false)
-      true
+      @attributes.key?(method)
     end
   end
 end

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ObjectTest < Minitest::Test
+  def test_handles_nil_attributes
+    object = MyTankInfo::Object.new(nil)
+
+    assert object.title.nil?
+  end
+
+  def test_handles_empty_attributes
+    object = MyTankInfo::Object.new({})
+
+    assert object.title.nil?
+  end
+
+  def test_object_doesnt_override_object_methods
+    attributes = {
+      "ObjectId" => "12345",
+      "ObjectType" => "tank",
+      "SensorName" => "REGULAR",
+      "PrivateMethods" => "not_good"
+    }
+
+    object = MyTankInfo::Object.new(attributes)
+
+    refute_equal "12345", object.object_id
+    assert_kind_of Integer, object.object_id
+
+    assert_equal "tank", object.object_type
+    assert_equal "tank", object.object_type
+    assert_equal "REGULAR", object.sensor_name
+
+    refute_equal "not_good", object.private_methods
+    assert_kind_of Array, object.private_methods
+  end
+end


### PR DESCRIPTION
This is the approach I was sketching out, which would avoid using open struct by just using the hash. This only works if all the attributes are simple getter methods, we don't need to do assignment with setter methods, and if we don't need to pass arguments to these methods.