### PR TITLE
Move ostruct from gemspec to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 
 gem "rake", "~> 13.0"
 gem "minitest", "~> 5.0"
+gem "ostruct"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     my_tank_info (1.1.2)
       activesupport (>= 8)
       faraday (~> 2)
-      ostruct
 
 GEM
   remote: https://rubygems.org/
@@ -83,6 +82,7 @@ DEPENDENCIES
   debug
   minitest (~> 5.0)
   my_tank_info!
+  ostruct
   rake (~> 13.0)
 
 BUNDLED WITH

--- a/my_tank_info.gemspec
+++ b/my_tank_info.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday", "~> 2"
   spec.add_dependency "activesupport", ">= 8"
-  spec.add_dependency "ostruct"
 
   spec.add_development_dependency "debug"
 


### PR DESCRIPTION
## Summary
- Remove `ostruct` from gemspec runtime dependencies
- Add `ostruct` to Gemfile for gem development

In Ruby 4.0, `ostruct` is an extracted gem that lives on rubygems.org. When this gem is sourced from git (e.g., `gem "my_tank_info", github: "pass/my_tank_info"`), Bundler can only resolve gemspec dependencies against the git source — so it can never find `ostruct`, breaking `bundle update` for consuming apps.

Consuming apps on Ruby 4.0+ still need `gem "ostruct"` in their own Gemfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)