### PR TITLE
Replace OpenStruct with hash to fix object_id warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,3 @@ gemspec
 
 gem "rake", "~> 13.0"
 gem "minitest", "~> 5.0"
-gem "ostruct"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,6 @@ GEM
     minitest (5.27.0)
     net-http (0.7.0)
       uri
-    ostruct (0.6.3)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -82,7 +81,6 @@ DEPENDENCIES
   debug
   minitest (~> 5.0)
   my_tank_info!
-  ostruct
   rake (~> 13.0)
 
 BUNDLED WITH

--- a/lib/my_tank_info.rb
+++ b/lib/my_tank_info.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "my_tank_info/version"
-require "ostruct"
+
 
 module MyTankInfo
   MYTI_DATE_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S%:z"

--- a/lib/my_tank_info/object.rb
+++ b/lib/my_tank_info/object.rb
@@ -4,20 +4,24 @@ require "active_support/core_ext/string/inflections"
 module MyTankInfo
   class Object
     def initialize(attributes)
-      # this ensures that when names are provided in camelcase (BeginDateTime) 
+      # this ensures that when names are provided in camelcase (BeginDateTime)
       # they are converted to snake_case (begin_date_time)
-      snake_case_keys = attributes&.transform_keys { |key| key.to_s.underscore }
       @original_attributes = attributes
-      @attributes = ::OpenStruct.new(snake_case_keys || {})
+      @attributes = (attributes || {}).transform_keys { |key| key.to_s.underscore.to_sym }
     end
 
     def method_missing(method, *args, &block)
-      attribute = @attributes.send(method, *args, &block)
-      attribute.is_a?(Hash) ? Object.new(attribute) : attribute
+      key = method.to_sym
+      if @attributes.key?(key)
+        value = @attributes[key]
+        value.is_a?(Hash) ? Object.new(value) : value
+      else
+        super
+      end
     end
 
     def respond_to_missing?(method, include_private = false)
-      true
+      @attributes.key?(method.to_sym) || super
     end
   end
 end


### PR DESCRIPTION
## Summary
- API returns an `object_id` field which causes `OpenStruct` to redefine Ruby's `Object#object_id`, producing warnings in Ruby 4.0
- Replaced `OpenStruct` with a plain hash in `MyTankInfo::Object`, using `method_missing` for attribute access
- Removed `ostruct` gem dependency from Gemfile

## Test plan
- [x] All 57 existing tests pass
- [ ] Verify `object_id` attribute is accessible on alarm objects without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)