### PR TITLE
Return nil for missing attributes to match OpenStruct behavior

### DIFF
--- a/lib/my_tank_info/object.rb
+++ b/lib/my_tank_info/object.rb
@@ -12,16 +12,12 @@ module MyTankInfo
 
     def method_missing(method, *args, &block)
       key = method.to_sym
-      if @attributes.key?(key)
-        value = @attributes[key]
-        value.is_a?(Hash) ? Object.new(value) : value
-      else
-        super
-      end
+      value = @attributes[key]
+      value.is_a?(Hash) ? Object.new(value) : value
     end
 
     def respond_to_missing?(method, include_private = false)
-      @attributes.key?(method.to_sym) || super
+      true
     end
   end
 end


### PR DESCRIPTION
## Summary
- Follows up on #17 — the OpenStruct→hash replacement raised `NoMethodError` for undefined attributes instead of returning `nil`
- Restores OpenStruct's nil-return behavior so callers accessing non-existent attributes don't break

## Test plan
- [x] All 57 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)