### PR TITLE
Fix direct @attributes access after OpenStruct removal

### DIFF
--- a/lib/my_tank_info/objects/environmental_sitegroup.rb
+++ b/lib/my_tank_info/objects/environmental_sitegroup.rb
@@ -3,7 +3,7 @@
 module MyTankInfo
   class EnvironmentalSitegroup < Object
     def sites
-      @attributes.sites.map { |site| Site.new(site) }
+      @attributes[:sites].map { |site| Site.new(site) }
     end
   end
 end

--- a/lib/my_tank_info/objects/inventory_sitegroup.rb
+++ b/lib/my_tank_info/objects/inventory_sitegroup.rb
@@ -3,7 +3,7 @@
 module MyTankInfo
   class InventorySitegroup < Object
     def sites
-      @attributes.sites.map { |site| Site.new(site) }
+      @attributes[:sites].map { |site| Site.new(site) }
     end
   end
 end

--- a/lib/my_tank_info/objects/notification_rule.rb
+++ b/lib/my_tank_info/objects/notification_rule.rb
@@ -3,7 +3,7 @@
 module MyTankInfo
   class NotificationRule < Object
     def contacts
-      @attributes.contacts.map { |contact| NotificationContact.new(contact) }
+      @attributes[:contacts].map { |contact| NotificationContact.new(contact) }
     end
   end
 end

--- a/lib/my_tank_info/objects/sitegroup_inventory_dashboard.rb
+++ b/lib/my_tank_info/objects/sitegroup_inventory_dashboard.rb
@@ -3,7 +3,7 @@
 module MyTankInfo
   class SitegroupInventoryDashboard < Object
     def sites
-      @attributes.sites.map { |site| Site.new(site) }
+      @attributes[:sites].map { |site| Site.new(site) }
     end
   end
 end


### PR DESCRIPTION
## Summary
- Four object subclasses accessed `@attributes` with dot notation (e.g. `@attributes.sites`) which worked with OpenStruct but fails with a plain hash
- Updated to bracket notation (`@attributes[:sites]`) in `InventorySitegroup`, `EnvironmentalSitegroup`, `SitegroupInventoryDashboard`, and `NotificationRule`

## Test plan
- [x] All 57 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)