### PR TITLE
Update transitive deps (psych, date, stringio)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
     bigdecimal (3.3.1)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
-    date (3.5.0)
+    date (3.5.1)
     debug (1.11.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
@@ -52,7 +52,7 @@ GEM
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
-    psych (5.2.6)
+    psych (5.3.1)
       date
       stringio
     rake (13.3.1)
@@ -63,7 +63,7 @@ GEM
     reline (0.6.2)
       io-console (~> 0.5)
     securerandom (0.4.1)
-    stringio (3.1.7)
+    stringio (3.2.0)
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
## Summary
- Bump psych 5.2.6 → 5.3.1, date 3.5.0 → 3.5.1, stringio 3.1.7 → 3.2.0
- Resolves ambiguous gem spec warning for psych

## Test plan
- [x] `bundle install` succeeds
- [ ] No more psych ambiguity warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)