### PR TITLE
Add JwtClient for JWT-based auth on new API endpoint

### DIFF
--- a/lib/my_tank_info.rb
+++ b/lib/my_tank_info.rb
@@ -7,6 +7,7 @@ module MyTankInfo
   MYTI_DATE_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S%:z"
 
   autoload :Client, "my_tank_info/client"
+  autoload :JwtClient, "my_tank_info/jwt_client"
   autoload :Object, "my_tank_info/object"
   autoload :Resource, "my_tank_info/resource"
   autoload :Collection, "my_tank_info/collection"
@@ -69,6 +70,8 @@ module MyTankInfo
   autoload :NotificationRulesResource, "my_tank_info/resources/notification_rules"
 
   autoload :TokensResource, "my_tank_info/resources/tokens"
+  autoload :AuthTokensResource, "my_tank_info/resources/auth_tokens"
+  autoload :AuthToken, "my_tank_info/objects/auth_token"
   autoload :SitesResource, "my_tank_info/resources/sites"
 
   autoload :DataReaderError, "my_tank_info/errors/data_reader_error"

--- a/lib/my_tank_info/client.rb
+++ b/lib/my_tank_info/client.rb
@@ -106,6 +106,14 @@ module MyTankInfo
       TokensResource.new(self).generate(username: username, password: password)
     end
 
+    def auth_headers
+      {Authorization: "Bearer #{api_key}"}
+    end
+
+    def with_auth_retry
+      yield
+    end
+
     def connection
       @connection ||= Faraday.new do |conn|
         conn.url_prefix = @base_url

--- a/lib/my_tank_info/jwt_client.rb
+++ b/lib/my_tank_info/jwt_client.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "faraday"
+
+module MyTankInfo
+  class JwtClient
+    DEFAULT_TIMEOUT = 120
+
+    attr_reader :base_url, :username,
+      :access_token, :refresh_token,
+      :access_token_expires_at, :refresh_token_expires_at,
+      :token_type, :scope
+
+    def initialize(base_url:, username: nil, password: nil,
+      access_token: nil, refresh_token: nil,
+      access_token_expires_at: nil, refresh_token_expires_at: nil,
+      token_type: nil, scope: nil,
+      adapter: Faraday.default_adapter, stubs: nil,
+      timeout: DEFAULT_TIMEOUT, open_timeout: nil)
+      @base_url = base_url
+      @username = username
+      @password = password
+      @access_token = access_token
+      @refresh_token = refresh_token
+      @access_token_expires_at = access_token_expires_at
+      @refresh_token_expires_at = refresh_token_expires_at
+      @token_type = token_type
+      @scope = scope
+      @adapter = adapter
+      @stubs = stubs
+      @timeout = timeout
+      @open_timeout = open_timeout
+    end
+
+    def auth_tokens
+      AuthTokensResource.new(self)
+    end
+
+    def auth_headers
+      access_token ? {Authorization: "Bearer #{access_token}"} : {}
+    end
+
+    def authenticate!
+      raise Error, "username and password are required to authenticate" unless @username && @password
+
+      apply_token!(auth_tokens.generate(username: @username, password: @password))
+    end
+
+    def refresh!
+      raise UnauthorizedError, "no refresh_token available" unless @refresh_token
+
+      apply_token!(auth_tokens.refresh(refresh_token: @refresh_token))
+    end
+
+    def with_auth_retry
+      yield
+    rescue UnauthorizedError
+      raise if @retrying
+
+      @retrying = true
+      begin
+        refresh_or_reauthenticate!
+        yield
+      ensure
+        @retrying = false
+      end
+    end
+
+    def connection
+      @connection ||= Faraday.new do |conn|
+        conn.url_prefix = @base_url
+        conn.request :json
+        conn.response :json, content_type: "application/json"
+        conn.options.timeout = @timeout if @timeout
+        conn.options.open_timeout = @open_timeout if @open_timeout
+        conn.adapter @adapter, @stubs
+      end
+    end
+
+    private
+
+    def refresh_or_reauthenticate!
+      refresh!
+    rescue UnauthorizedError
+      raise unless @username && @password
+
+      authenticate!
+    end
+
+    def apply_token!(token)
+      @access_token = token.access_token
+      @refresh_token = token.refresh_token
+      @access_token_expires_at = token.access_token_expires_at
+      @refresh_token_expires_at = token.refresh_token_expires_at
+      @token_type = token.token_type
+      @scope = token.scope
+      token
+    end
+  end
+end

--- a/lib/my_tank_info/objects/auth_token.rb
+++ b/lib/my_tank_info/objects/auth_token.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module MyTankInfo
+  class AuthToken < Object
+    attr_reader :access_token_expires_at, :refresh_token_expires_at
+
+    def initialize(attributes, now: Time.now)
+      super(attributes)
+      @access_token_expires_at = now + expires_in if expires_in
+      @refresh_token_expires_at = now + refresh_expires_in if refresh_expires_in
+    end
+  end
+end

--- a/lib/my_tank_info/resource.rb
+++ b/lib/my_tank_info/resource.rb
@@ -8,24 +8,34 @@ module MyTankInfo
       @client = client
     end
 
-    def get_request(url, params: {}, headers: {})
-      handle_response client.connection.get(url, params, default_headers.merge(headers))
+    def get_request(url, params: {}, headers: {}, skip_auth: false)
+      with_retry(skip_auth) do
+        handle_response client.connection.get(url, params, request_headers(headers, skip_auth))
+      end
     end
 
-    def post_request(url, body:, headers: {})
-      handle_response client.connection.post(url, body, default_headers.merge(headers))
+    def post_request(url, body:, headers: {}, skip_auth: false)
+      with_retry(skip_auth) do
+        handle_response client.connection.post(url, body, request_headers(headers, skip_auth))
+      end
     end
 
-    def patch_request(url, body:, headers: {})
-      handle_response client.connection.patch(url, body, default_headers.merge(headers))
+    def patch_request(url, body:, headers: {}, skip_auth: false)
+      with_retry(skip_auth) do
+        handle_response client.connection.patch(url, body, request_headers(headers, skip_auth))
+      end
     end
 
-    def put_request(url, body:, headers: {})
-      handle_response client.connection.put(url, body, default_headers.merge(headers))
+    def put_request(url, body:, headers: {}, skip_auth: false)
+      with_retry(skip_auth) do
+        handle_response client.connection.put(url, body, request_headers(headers, skip_auth))
+      end
     end
 
-    def delete_request(url, params: {}, headers: {})
-      handle_response client.connection.delete(url, params, default_headers.merge(headers))
+    def delete_request(url, params: {}, headers: {}, skip_auth: false)
+      with_retry(skip_auth) do
+        handle_response client.connection.delete(url, params, request_headers(headers, skip_auth))
+      end
     end
 
     private
@@ -41,14 +51,20 @@ module MyTankInfo
       end
     end
 
-    def default_headers
-      {Authorization: "Bearer #{client.api_key}"}
+    def request_headers(headers, skip_auth)
+      skip_auth ? headers : client.auth_headers.merge(headers)
+    end
+
+    def with_retry(skip_auth, &block)
+      return yield if skip_auth
+
+      client.with_auth_retry(&block)
     end
 
     def handle_response(response)
       message = response.body
 
-      message = 
+      message =
         if message.is_a?(Array)
           message = message.join(". ")
         else

--- a/lib/my_tank_info/resources/auth_tokens.rb
+++ b/lib/my_tank_info/resources/auth_tokens.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module MyTankInfo
+  class AuthTokensResource < Resource
+    def generate(username:, password:)
+      response = post_request(
+        "api/token",
+        body: {username: username, password: password},
+        skip_auth: true
+      )
+      AuthToken.new(response.body)
+    end
+
+    def refresh(refresh_token:)
+      response = post_request(
+        "api/token/refresh",
+        body: {refreshToken: refresh_token},
+        skip_auth: true
+      )
+      AuthToken.new(response.body)
+    end
+  end
+end

--- a/test/fixtures/auth_tokens/generate.json
+++ b/test/fixtures/auth_tokens/generate.json
@@ -1,0 +1,8 @@
+{
+  "accessToken": "access-token-initial",
+  "tokenType": "Bearer",
+  "expiresIn": 3600,
+  "refreshToken": "refresh-token-initial",
+  "refreshExpiresIn": 2592000,
+  "scope": "external"
+}

--- a/test/fixtures/auth_tokens/refresh.json
+++ b/test/fixtures/auth_tokens/refresh.json
@@ -1,0 +1,8 @@
+{
+  "accessToken": "access-token-refreshed",
+  "tokenType": "Bearer",
+  "expiresIn": 3600,
+  "refreshToken": "refresh-token-rotated",
+  "refreshExpiresIn": 2592000,
+  "scope": "external"
+}

--- a/test/jwt_client_test.rb
+++ b/test/jwt_client_test.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class JwtClientTest < Minitest::Test
+  GENERATE_BODY = File.read("test/fixtures/auth_tokens/generate.json")
+  REFRESH_BODY = File.read("test/fixtures/auth_tokens/refresh.json")
+  JSON_CT = {"Content-Type" => "application/json"}.freeze
+
+  class ProtectedResource < MyTankInfo::Resource
+    def fetch
+      get_request("/protected")
+    end
+  end
+
+  def test_auth_headers_empty_without_token
+    client = MyTankInfo::JwtClient.new(base_url: "http://example.test")
+    assert_equal({}, client.auth_headers)
+  end
+
+  def test_auth_headers_with_existing_access_token
+    client = MyTankInfo::JwtClient.new(base_url: "http://example.test", access_token: "abc")
+    assert_equal({Authorization: "Bearer abc"}, client.auth_headers)
+  end
+
+  def test_authenticate_populates_token_state
+    stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.post("/api/token", {username: "u", password: "p"}.to_json) do
+        [200, JSON_CT, GENERATE_BODY]
+      end
+    end
+
+    client = MyTankInfo::JwtClient.new(
+      base_url: "http://example.test",
+      username: "u", password: "p",
+      adapter: :test, stubs: stubs
+    )
+    client.authenticate!
+
+    assert_equal "access-token-initial", client.access_token
+    assert_equal "refresh-token-initial", client.refresh_token
+    assert_equal "Bearer", client.token_type
+    assert_equal "external", client.scope
+    assert client.access_token_expires_at > Time.now
+    assert client.refresh_token_expires_at > Time.now
+  end
+
+  def test_authenticate_requires_credentials
+    client = MyTankInfo::JwtClient.new(base_url: "http://example.test")
+    assert_raises MyTankInfo::Error do
+      client.authenticate!
+    end
+  end
+
+  def test_refresh_requires_refresh_token
+    client = MyTankInfo::JwtClient.new(base_url: "http://example.test")
+    assert_raises MyTankInfo::UnauthorizedError do
+      client.refresh!
+    end
+  end
+
+  def test_request_retries_after_refresh_on_401
+    protected_calls = 0
+    stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.get("/protected") do |env|
+        protected_calls += 1
+        if protected_calls == 1
+          assert_equal "Bearer initial-access", env.request_headers["Authorization"]
+          [401, JSON_CT, '"expired"']
+        else
+          assert_equal "Bearer access-token-refreshed", env.request_headers["Authorization"]
+          [200, JSON_CT, '{"ok":true}']
+        end
+      end
+      stub.post("/api/token/refresh", {refreshToken: "initial-refresh"}.to_json) do
+        [200, JSON_CT, REFRESH_BODY]
+      end
+    end
+
+    client = MyTankInfo::JwtClient.new(
+      base_url: "http://example.test",
+      access_token: "initial-access",
+      refresh_token: "initial-refresh",
+      adapter: :test, stubs: stubs
+    )
+
+    response = ProtectedResource.new(client).fetch
+
+    assert_equal 200, response.status
+    assert_equal 2, protected_calls
+    assert_equal "access-token-refreshed", client.access_token
+    assert_equal "refresh-token-rotated", client.refresh_token
+  end
+
+  def test_request_reauthenticates_when_refresh_fails_with_credentials
+    protected_calls = 0
+    stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.get("/protected") do
+        protected_calls += 1
+        (protected_calls == 1) ? [401, JSON_CT, '"expired"'] : [200, JSON_CT, '{"ok":true}']
+      end
+      stub.post("/api/token/refresh", {refreshToken: "stale-refresh"}.to_json) do
+        [401, JSON_CT, '"refresh expired"']
+      end
+      stub.post("/api/token", {username: "u", password: "p"}.to_json) do
+        [200, JSON_CT, GENERATE_BODY]
+      end
+    end
+
+    client = MyTankInfo::JwtClient.new(
+      base_url: "http://example.test",
+      username: "u", password: "p",
+      access_token: "stale-access",
+      refresh_token: "stale-refresh",
+      adapter: :test, stubs: stubs
+    )
+
+    response = ProtectedResource.new(client).fetch
+
+    assert_equal 200, response.status
+    assert_equal "access-token-initial", client.access_token
+    assert_equal "refresh-token-initial", client.refresh_token
+  end
+
+  def test_request_raises_when_refresh_fails_without_credentials
+    stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.get("/protected") { [401, JSON_CT, '"expired"'] }
+      stub.post("/api/token/refresh", {refreshToken: "stale-refresh"}.to_json) do
+        [401, JSON_CT, '"refresh expired"']
+      end
+    end
+
+    client = MyTankInfo::JwtClient.new(
+      base_url: "http://example.test",
+      access_token: "stale-access",
+      refresh_token: "stale-refresh",
+      adapter: :test, stubs: stubs
+    )
+
+    assert_raises MyTankInfo::UnauthorizedError do
+      ProtectedResource.new(client).fetch
+    end
+  end
+
+  def test_request_does_not_retry_a_second_time
+    protected_calls = 0
+    stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.get("/protected") do
+        protected_calls += 1
+        [401, JSON_CT, '"still expired"']
+      end
+      stub.post("/api/token/refresh", {refreshToken: "initial-refresh"}.to_json) do
+        [200, JSON_CT, REFRESH_BODY]
+      end
+    end
+
+    client = MyTankInfo::JwtClient.new(
+      base_url: "http://example.test",
+      access_token: "initial-access",
+      refresh_token: "initial-refresh",
+      adapter: :test, stubs: stubs
+    )
+
+    assert_raises MyTankInfo::UnauthorizedError do
+      ProtectedResource.new(client).fetch
+    end
+    assert_equal 2, protected_calls
+  end
+
+  def test_timeout_options_applied_to_connection
+    client = MyTankInfo::JwtClient.new(base_url: "http://example.test", timeout: 30, open_timeout: 5)
+
+    assert_equal 30, client.connection.options.timeout
+    assert_equal 5, client.connection.options.open_timeout
+  end
+end

--- a/test/resources/auth_tokens_test.rb
+++ b/test/resources/auth_tokens_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AuthTokensResourceTest < Minitest::Test
+  def test_generate
+    captured_headers = nil
+    stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.post("/api/token", {username: "kyle@example.com", password: "p@33w0rd"}.to_json) do |env|
+        captured_headers = env.request_headers
+        [200, {"Content-Type" => "application/json"}, File.read("test/fixtures/auth_tokens/generate.json")]
+      end
+    end
+
+    client = MyTankInfo::JwtClient.new(base_url: "http://example.test", adapter: :test, stubs: stubs)
+    token = client.auth_tokens.generate(username: "kyle@example.com", password: "p@33w0rd")
+
+    assert_nil captured_headers["Authorization"]
+    assert_equal MyTankInfo::AuthToken, token.class
+    assert_equal "access-token-initial", token.access_token
+    assert_equal "refresh-token-initial", token.refresh_token
+    assert_equal 3600, token.expires_in
+    assert_equal 2_592_000, token.refresh_expires_in
+    assert_equal "Bearer", token.token_type
+    assert_equal "external", token.scope
+  end
+
+  def test_refresh
+    captured_headers = nil
+    stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.post("/api/token/refresh", {refreshToken: "refresh-token-initial"}.to_json) do |env|
+        captured_headers = env.request_headers
+        [200, {"Content-Type" => "application/json"}, File.read("test/fixtures/auth_tokens/refresh.json")]
+      end
+    end
+
+    client = MyTankInfo::JwtClient.new(base_url: "http://example.test", adapter: :test, stubs: stubs)
+    token = client.auth_tokens.refresh(refresh_token: "refresh-token-initial")
+
+    assert_nil captured_headers["Authorization"]
+    assert_equal "access-token-refreshed", token.access_token
+    assert_equal "refresh-token-rotated", token.refresh_token
+  end
+
+  def test_auth_token_computes_expires_at_timestamps
+    now = Time.utc(2026, 5, 12, 12, 0, 0)
+    attrs = {
+      "accessToken" => "a",
+      "refreshToken" => "r",
+      "expiresIn" => 3600,
+      "refreshExpiresIn" => 2_592_000
+    }
+
+    token = MyTankInfo::AuthToken.new(attrs, now: now)
+
+    assert_equal now + 3600, token.access_token_expires_at
+    assert_equal now + 2_592_000, token.refresh_token_expires_at
+  end
+end


### PR DESCRIPTION
## Summary

Adds a parallel `MyTankInfo::JwtClient` for the new MyTankInfo API endpoint, which authenticates with JWT (access + refresh tokens) instead of the static API key the existing `Client` uses.

- New `JwtClient` holds tokens, exposes `authenticate!` / `refresh!`, and auto-refreshes on 401 then retries the original request once.
- Falls back to a full re-auth (`POST /api/token` w/ username + password) if the refresh token has also expired and credentials were provided at init.
- Tokens (and expiry timestamps) are exposed as readers and accepted at init, so callers can persist them across processes.
- Existing `Client` / api_key flow is unchanged behaviorally; only added a one-line `auth_headers` delegate and a no-op `with_auth_retry { yield }` so `Resource` can route through the client.

## Why

A new MyTankInfo API endpoint uses JWT auth with 60-min access tokens and 30-day refresh tokens. The current gem hardcodes `Bearer <api_key>` in `Resource#default_headers`, so it can't talk to the new endpoint as-is. Their tech lead confirmed clients should wrap requests to handle refresh automatically.

## What changed

- `lib/my_tank_info/jwt_client.rb` (new) — parallel client, JWT state, `with_auth_retry`.
- `lib/my_tank_info/resources/auth_tokens.rb` (new) — `generate(username:, password:)` and `refresh(refresh_token:)`, both `skip_auth: true`.
- `lib/my_tank_info/objects/auth_token.rb` (new) — wraps the API response, computes `access_token_expires_at` / `refresh_token_expires_at`.
- `lib/my_tank_info/resource.rb` — `default_headers` now delegates to `client.auth_headers`; each verb takes `skip_auth:` and wraps in `client.with_auth_retry`.
- `lib/my_tank_info/client.rb` — one-line `auth_headers`, no-op `with_auth_retry`.
- `lib/my_tank_info.rb` — three new autoloads.

## Reviewer notes

- `JwtClient#base_url` is a required kwarg (no default) — the production host for the new endpoint is still TBD; callers pass it explicitly for now.
- Naming open: `JwtClient` vs. `OAuthClient`. Happy to rename before tagging a release.
- This PR is the auth layer only. Resource accessors on `JwtClient` will be added in follow-ups as the new endpoints are documented.
- No thread-safety guards on refresh; matches existing single-threaded conventions in the gem.

## Test plan

- [x] `bundle exec rake test` — 77 runs, 207 assertions, 0 failures.
- [x] AuthTokensResource: `generate` + `refresh` happy paths assert **no Authorization header** is sent.
- [x] JwtClient retry: 401 → refresh → retry → 200.
- [x] JwtClient retry: 401 → refresh 401 → re-auth (creds present) → retry → 200.
- [x] JwtClient retry: 401 → refresh 401 → no creds → raises `UnauthorizedError`.
- [x] JwtClient retry: stops after one retry (no infinite recursion if second call still 401s).
- [x] `AuthToken` expiry timestamps computed against frozen `Time.now`.
- [ ] Manual smoke against the real endpoint (blocked on prod base URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)