### PR TITLE
Add run_atg_command to SitesResource

### DIFF
--- a/lib/my_tank_info.rb
+++ b/lib/my_tank_info.rb
@@ -26,6 +26,7 @@ module MyTankInfo
   autoload :LineLeakResult, "my_tank_info/objects/line_leak_result"
   autoload :CsldResult, "my_tank_info/objects/csld_result"
   autoload :SensorStatusResult, "my_tank_info/objects/sensor_status_result"
+  autoload :AtgCommandResult, "my_tank_info/objects/atg_command_result"
 
   autoload :SitegroupInventoryDashboard, "my_tank_info/objects/sitegroup_inventory_dashboard"
   autoload :TankDailyUsageRecord, "my_tank_info/objects/tank_daily_usage_record"

--- a/lib/my_tank_info/objects/atg_command_result.rb
+++ b/lib/my_tank_info/objects/atg_command_result.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module MyTankInfo
+  class AtgCommandResult < Object
+  end
+end

--- a/lib/my_tank_info/resources/sites.rb
+++ b/lib/my_tank_info/resources/sites.rb
@@ -11,6 +11,13 @@ module MyTankInfo
       Collection.from_response(response, type: SensorStatusResult)
     end
 
+    def run_atg_command(site_id:, command:, timeout_seconds: nil)
+      path = "api/sites/#{site_id}/runatgcommand"
+      path += "?timeoutSeconds=#{timeout_seconds}" unless timeout_seconds.nil?
+
+      AtgCommandResult.new post_request(path, body: {command: command}).body
+    end
+
     def passive_poll(site_id:, timeout_seconds: nil)
       path = "api/sites/#{site_id}/passivepoll"
       path += "?timeoutSeconds=#{timeout_seconds}" unless timeout_seconds.nil?

--- a/test/fixtures/sites/run_atg_command.json
+++ b/test/fixtures/sites/run_atg_command.json
@@ -1,0 +1,7 @@
+{
+  "status": "ok",
+  "command": "I20100",
+  "results": "I20100\nMAY 19, 2026  9:42 AM\n\nIN-TANK INVENTORY\n\nTANK PRODUCT             VOLUME TC VOLUME   ULLAGE   HEIGHT    WATER     TEMP\n  1  REGULAR              1024     1019      4976    36.21     0.00    62.4\n",
+  "event_id": 123456,
+  "poll_duration_seconds": 4.27
+}

--- a/test/resources/sites_test.rb
+++ b/test/resources/sites_test.rb
@@ -252,4 +252,88 @@ class SitesResourceTest < Minitest::Test
       client.sites.passive_poll(site_id: SITE_ID)
     end
   end
+
+  def test_run_atg_command
+    stub =
+      stub_request(
+        "/api/sites/#{SITE_ID}/runatgcommand",
+        method: :post,
+        body: {command: "I20100"},
+        response: stub_response(fixture: "sites/run_atg_command")
+      )
+
+    client = MyTankInfo::Client.new(api_key: "fake", adapter: :test, stubs: stub)
+    result = client.sites.run_atg_command(site_id: SITE_ID, command: "I20100")
+
+    assert_equal MyTankInfo::AtgCommandResult, result.class
+    assert_equal "ok", result.status
+    assert_equal "I20100", result.command
+    assert_equal 123456, result.event_id
+    assert_in_delta 4.27, result.poll_duration_seconds
+    assert_match(/IN-TANK INVENTORY/, result.results)
+  end
+
+  def test_run_atg_command_with_timeout_seconds
+    stub =
+      stub_request(
+        "/api/sites/#{SITE_ID}/runatgcommand?timeoutSeconds=60",
+        method: :post,
+        body: {command: "I20100"},
+        response: stub_response(fixture: "sites/run_atg_command")
+      )
+
+    client = MyTankInfo::Client.new(api_key: "fake", adapter: :test, stubs: stub)
+    result = client.sites.run_atg_command(site_id: SITE_ID, command: "I20100", timeout_seconds: 60)
+
+    assert_equal MyTankInfo::AtgCommandResult, result.class
+    assert_equal "ok", result.status
+  end
+
+  def test_run_atg_command_unauthorized
+    stub =
+      stub_request(
+        "/api/sites/#{SITE_ID}/runatgcommand",
+        method: :post,
+        body: {command: "I20100"},
+        response: [401, {"Content-Type" => "application/json"}, '"Invalid token"']
+      )
+
+    client = MyTankInfo::Client.new(api_key: "bad_key", adapter: :test, stubs: stub)
+
+    assert_raises MyTankInfo::UnauthorizedError do
+      client.sites.run_atg_command(site_id: SITE_ID, command: "I20100")
+    end
+  end
+
+  def test_run_atg_command_forbidden
+    stub =
+      stub_request(
+        "/api/sites/#{SITE_ID}/runatgcommand",
+        method: :post,
+        body: {command: "I20100"},
+        response: [403, {"Content-Type" => "application/json"}, '"Access denied"']
+      )
+
+    client = MyTankInfo::Client.new(api_key: "fake", adapter: :test, stubs: stub)
+
+    assert_raises MyTankInfo::RequestForbiddenError do
+      client.sites.run_atg_command(site_id: SITE_ID, command: "I20100")
+    end
+  end
+
+  def test_run_atg_command_not_found
+    stub =
+      stub_request(
+        "/api/sites/#{SITE_ID}/runatgcommand",
+        method: :post,
+        body: {command: "I20100"},
+        response: [404, {"Content-Type" => "application/json"}, '"Site not found"']
+      )
+
+    client = MyTankInfo::Client.new(api_key: "fake", adapter: :test, stubs: stub)
+
+    assert_raises MyTankInfo::NotFoundError do
+      client.sites.run_atg_command(site_id: SITE_ID, command: "I20100")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Wraps `POST /api/sites/{siteId}/runatgcommand` — runs an ATG special command synchronously and returns the device's reply. Added as a method on the existing `SitesResource` alongside `passive_poll`, since the path/shape is identical (site-scoped POST with optional `timeoutSeconds` query).

## Usage

\`\`\`ruby
result = client.sites.run_atg_command(site_id: 123, command: "I20100")
result.status                  # "ok"
result.command                 # "I20100"
result.results                 # device text response
result.event_id                # 123456
result.poll_duration_seconds   # 4.27
\`\`\`

Optional `timeout_seconds:` keyword maps to the `timeoutSeconds` query param (API default 300).

## Changes

- New `MyTankInfo::AtgCommandResult` object (empty subclass — base `Object` handles attribute access)
- New `run_atg_command(site_id:, command:, timeout_seconds: nil)` on `SitesResource`
- Autoload entry in `lib/my_tank_info.rb`
- Fixture + 5 tests (happy path, timeout query, 401/403/404)

## Test plan

- [x] \`bundle exec rake test\` — 82 runs, 219 assertions, 0 failures
- [ ] Smoke against real API (reviewer, optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)