### PR TITLE
Raise UnexpectedResponseError on unhandled status / non-JSON body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.2.0] - 2026-06-02
+- Raise `MyTankInfo::UnexpectedResponseError` (capturing the HTTP status and a truncated response body) when the API returns an unexpected status code or a non-JSON body, instead of letting the raw string flow downstream and surface as an opaque `NoMethodError`
+
 ## [1.1.1] - 2021-10-18
 - Fix bug in NotificationContact delete logic
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    my_tank_info (1.1.2)
+    my_tank_info (1.2.0)
       activesupport (>= 8)
       faraday (~> 2)
 

--- a/lib/my_tank_info.rb
+++ b/lib/my_tank_info.rb
@@ -6,6 +6,18 @@ require_relative "my_tank_info/version"
 module MyTankInfo
   MYTI_DATE_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S%:z"
 
+  # Cap a captured response body before it goes into an exception message so a
+  # large error page (e.g. an HTML 502 from a proxy) doesn't bloat the error
+  # tracker payload while still preserving enough to troubleshoot.
+  MAX_ERROR_BODY_LENGTH = 500
+
+  def self.truncate_error_body(body)
+    string = body.to_s
+    return string if string.length <= MAX_ERROR_BODY_LENGTH
+
+    "#{string[0, MAX_ERROR_BODY_LENGTH]}... (truncated #{string.length - MAX_ERROR_BODY_LENGTH} chars)"
+  end
+
   autoload :Client, "my_tank_info/client"
   autoload :JwtClient, "my_tank_info/jwt_client"
   autoload :Object, "my_tank_info/object"
@@ -81,4 +93,5 @@ module MyTankInfo
   autoload :NotFoundError, "my_tank_info/errors/not_found_error"
   autoload :RequestForbiddenError, "my_tank_info/errors/request_forbidden_error"
   autoload :UnauthorizedError, "my_tank_info/errors/unauthorized_error"
+  autoload :UnexpectedResponseError, "my_tank_info/errors/unexpected_response_error"
 end

--- a/lib/my_tank_info/collection.rb
+++ b/lib/my_tank_info/collection.rb
@@ -6,10 +6,20 @@ module MyTankInfo
 
     def self.from_response(response, type:, filter_attribute: nil, filter_value: nil)
       body =
-        if response.body.instance_of?(Hash)
+        case response.body
+        when Hash
           [response.body]
-        else
+        when Array
           response.body
+        else
+          # A successful status with a body that isn't the JSON object/array we
+          # expect (e.g. an empty or plain-text body). Calling `.map` on it
+          # would raise an opaque NoMethodError - capture the status and body
+          # so the unexpected response is diagnosable.
+          raise UnexpectedResponseError,
+            "Expected a JSON object or array from the API but got " \
+            "#{response.body.class} (HTTP #{response.status}) - " \
+            "#{MyTankInfo.truncate_error_body(response.body)}"
         end
 
       @collection = new(

--- a/lib/my_tank_info/errors/unexpected_response_error.rb
+++ b/lib/my_tank_info/errors/unexpected_response_error.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module MyTankInfo
+  # Raised when the API returns a response we don't know how to handle - an
+  # unexpected HTTP status, or a body that isn't the JSON object/array the
+  # caller expects (e.g. an HTML error page from a proxy, or an empty/plain
+  # text body). The message captures the status code and (truncated) body so
+  # the failure can actually be diagnosed instead of surfacing as a generic
+  # `NoMethodError` deeper in the stack.
+  class UnexpectedResponseError < Error; end
+end

--- a/lib/my_tank_info/resource.rb
+++ b/lib/my_tank_info/resource.rb
@@ -72,6 +72,8 @@ module MyTankInfo
         end
 
       case response.status
+      when 200..299
+        response
       when 400
         raise Error, "Your request was malformed - #{message}"
       when 401
@@ -83,14 +85,21 @@ module MyTankInfo
       when 429
         raise Error, "Your request exceeded the API rate limit - #{message}"
       when 500
-        if message.downcase.include?("datareader")
+        if message.to_s.downcase.include?("datareader")
           raise DataReaderError, message
         else
           raise InternalServerError, "We were unable to perform the request due to server-side problems - #{message}"
         end
+      else
+        # Any other status is one we don't expect from the API. Faraday isn't
+        # configured to raise on these, and its JSON middleware only parses
+        # `application/json` responses - so without this the raw (often
+        # non-JSON) body flows downstream and blows up as a NoMethodError when
+        # something tries to treat it as a parsed object. Surface the status
+        # and body instead so the failure is diagnosable.
+        raise UnexpectedResponseError,
+          "The API returned an unexpected response (HTTP #{response.status}) - #{MyTankInfo.truncate_error_body(message)}"
       end
-
-      response
     end
   end
 end

--- a/lib/my_tank_info/version.rb
+++ b/lib/my_tank_info/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MyTankInfo
-  VERSION = "1.1.2"
+  VERSION = "1.2.0"
 end

--- a/test/collection_test.rb
+++ b/test/collection_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CollectionTest < Minitest::Test
+  FakeResponse = Struct.new(:status, :body)
+
+  def test_from_response_wraps_a_single_hash
+    response = FakeResponse.new(200, {"id" => 1})
+    collection = MyTankInfo::Collection.from_response(response, type: MyTankInfo::TankLeakResult)
+
+    assert_equal 1, collection.size
+    assert_equal MyTankInfo::TankLeakResult, collection.data.first.class
+  end
+
+  def test_from_response_keeps_an_array
+    response = FakeResponse.new(200, [{"id" => 1}, {"id" => 2}])
+    collection = MyTankInfo::Collection.from_response(response, type: MyTankInfo::TankLeakResult)
+
+    assert_equal 2, collection.size
+  end
+
+  def test_from_response_raises_on_unexpected_body
+    response = FakeResponse.new(200, "Not the JSON we expected")
+
+    error =
+      assert_raises MyTankInfo::UnexpectedResponseError do
+        MyTankInfo::Collection.from_response(response, type: MyTankInfo::TankLeakResult)
+      end
+
+    assert_includes error.message, "HTTP 200"
+    assert_includes error.message, "Not the JSON we expected"
+  end
+
+  def test_truncate_error_body_returns_short_bodies_unchanged
+    assert_equal "short body", MyTankInfo.truncate_error_body("short body")
+  end
+
+  def test_truncate_error_body_caps_long_bodies
+    overflow = 50
+    long = "x" * (MyTankInfo::MAX_ERROR_BODY_LENGTH + overflow)
+    truncated = MyTankInfo.truncate_error_body(long)
+
+    assert truncated.start_with?("x" * MyTankInfo::MAX_ERROR_BODY_LENGTH)
+    assert_includes truncated, "truncated #{overflow} chars"
+  end
+end

--- a/test/resources/tank_leak_results_test.rb
+++ b/test/resources/tank_leak_results_test.rb
@@ -16,4 +16,39 @@ class TankLeakResultsResourceTest < Minitest::Test
     assert_equal MyTankInfo::Collection, results.class
     assert_equal MyTankInfo::TankLeakResult, results.data.first.class
   end
+
+  def test_list_raises_on_unexpected_status
+    stub =
+      stub_request(
+        "/api/environmental/sites/#{SITE_ID}/tankleaks",
+        response: [503, {"Content-Type" => "text/html"}, "<html><body>Service Unavailable</body></html>"]
+      )
+
+    client = MyTankInfo::Client.new(api_key: "fake", adapter: :test, stubs: stub)
+
+    error =
+      assert_raises MyTankInfo::UnexpectedResponseError do
+        client.tank_leak_results.list(site_id: SITE_ID)
+      end
+
+    assert_includes error.message, "503"
+    assert_includes error.message, "Service Unavailable"
+  end
+
+  def test_list_raises_on_non_json_body
+    stub =
+      stub_request(
+        "/api/environmental/sites/#{SITE_ID}/tankleaks",
+        response: [200, {"Content-Type" => "text/html"}, "Unexpected plain text body"]
+      )
+
+    client = MyTankInfo::Client.new(api_key: "fake", adapter: :test, stubs: stub)
+
+    error =
+      assert_raises MyTankInfo::UnexpectedResponseError do
+        client.tank_leak_results.list(site_id: SITE_ID)
+      end
+
+    assert_includes error.message, "Unexpected plain text body"
+  end
 end


### PR DESCRIPTION
## Why

PASS Tools error **PASS-TOOLS-6K**: `NoMethodError: undefined method 'map' for an instance of String` in `MyTankInfo::DeviceSyncJob`.

Root cause is in this gem:

- `Resource#handle_response` only raised for statuses **400/401/403/404/429/500**, and the Faraday connection isn't configured with `raise_error`. Its JSON response middleware only parses bodies whose `Content-Type` is `application/json`.
- So any *other* status (e.g. an HTML `502/503/504` from a proxy/Azure cold-start) — or a `2xx` with a non-JSON body — fell straight through, returning a response whose `body` was a raw `String`. `Collection.from_response` then called `body.map { ... }` on that String and crashed with an opaque `NoMethodError`, with no record of the status code or the body that came back.

## What

- **Check the status code** in `handle_response`: add `when 200..299` (return the response) and an `else` that raises a new `MyTankInfo::UnexpectedResponseError` for anything unhandled, including the HTTP status and a truncated copy of the body.
- **Guard the body type** in `Collection.from_response`: when a successful status carries a body that isn't a Hash/Array, raise the same descriptive error instead of `.map`-ing a String.
- **Capture the body** via `MyTankInfo.truncate_error_body` (capped at 500 chars) so a large HTML error page doesn't bloat the error-tracker payload while preserving enough to troubleshoot.
- Hardened the `500` DataReader check with `to_s` so a non-string 500 body can't itself raise.

## Tests

- `test/collection_test.rb` — `from_response` wraps a Hash, keeps an Array, raises on an unexpected body; truncation helper unit tests.
- `test/resources/tank_leak_results_test.rb` — `list` raises `UnexpectedResponseError` on an unexpected status (503/HTML) and on a 2xx non-JSON body.

Full suite green (89 runs, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)